### PR TITLE
Add "Show password" button, add info to auth options

### DIFF
--- a/wpa_supplicant/wpa_gui-haiku/locales/en.catkeys
+++ b/wpa_supplicant/wpa_gui-haiku/locales/en.catkeys
@@ -1,13 +1,15 @@
-1	English	application/x-vnd.malinen-wpa_supplicant	4272080571
+1	English	application/x-vnd.malinen-wpa_supplicant	2596284191
+Password:	wpa_supplicant		Password:
+Store this configuration	wpa_supplicant		Store this configuration
+WEP ‒ insecure encryption	wpa_supplicant		WEP ‒ insecure encryption
+Cancel	wpa_supplicant		Cancel
+OK	wpa_supplicant		OK
+Show password	wpa_supplicant		Show password
+Open ‒ no encryption	wpa_supplicant		Open ‒ no encryption
 Authentication:	wpa_supplicant		Authentication:
 Failed to join network. (Incorrect password?)	wpa_supplicant		Failed to join network. (Incorrect password?)
-Store this configuration	wpa_supplicant		Store this configuration
-Password:	wpa_supplicant		Password:
 WPA/WPA2	wpa_supplicant		WPA/WPA2
 Connect to a WiFi network	wpa_supplicant		Connect to a WiFi network
 Password format invalid!	wpa_supplicant		Password format invalid!
-WEP	wpa_supplicant		WEP
+Hide password	wpa_supplicant		Hide password
 Network name:	wpa_supplicant		Network name:
-OK	wpa_supplicant		OK
-Cancel	wpa_supplicant		Cancel
-Open	wpa_supplicant	Open network	Open


### PR DESCRIPTION
* "Show password" button toggles hiding the entered text by replacing the letters with "*".

* Add info about security to the authentication options.

  When building the package, the flag "CONFIG_WEP=y" should be set, to manually enable WEP.
  We now explicitly say WEP is insecure, so if the user is determined to use it anyway, we shouldn't
  stand in their way.

* Updated en.catkeys